### PR TITLE
chore: Move over most cronjobs and all schedulers

### DIFF
--- a/env/templates/arcalos-boot-config-scheduler.yaml
+++ b/env/templates/arcalos-boot-config-scheduler.yaml
@@ -1,0 +1,57 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  name: arcalos-boot-config-scheduler
+spec:
+  plugins:
+    entries:
+      - label
+  postsubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      name: release
+      context: release
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      context: arcalos
+      name: arcalos
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - arcalos
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      - labels:
+          entries:
+          - updatebot
+        milestone: ""
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test arcalos
+      trigger: (?m)^/test( all| arcalos),?(s+|$)

--- a/env/templates/arcalos-cleanup-cj.yaml
+++ b/env/templates/arcalos-cleanup-cj.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: arcalos-cleanup-config
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    jx step git credentials
+    git config --global credential.helper store 
+ 
+    gcloud auth activate-service-account --key-file $GKE_SA_KEY_FILE
+ 
+    git clone https://github.com/cloudbees/arcalos
+    pushd arcalos
+      ./cleanup.sh
+    popd
+    sac cleanup
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: jx-arcalos-cleanup
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: arcalos-cleanup
+            release: jx
+        spec:
+          containers:
+          - command:
+            - /bin/entrypoint.sh
+            env:
+            - name: GKE_SA_KEY_FILE
+              value: "/secret/sa/ci_bot.json"
+            - name: XDG_CONFIG_HOME
+              value: "/root"
+            image: gcr.io/jenkinsxio/sac:0.0.58
+            imagePullPolicy: IfNotPresent
+            name: arcalos-cleanup
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+              - name: sa
+                mountPath: /secret/sa/ci_bot.json
+                readOnly: true
+                subPath: ci_bot.json
+              - name: cleanup-config
+                mountPath: /bin/entrypoint.sh
+                readOnly: true
+                subPath: entrypoint.sh
+          volumes:
+            - name: sa
+              secret:
+                secretName: arcalos-alpha-prod-secret
+                items:
+                - key: arcalos_prod_sa
+                  path: ci_bot.json
+            - name: cleanup-config
+              configMap:
+                defaultMode: 0700
+                name: arcalos-cleanup-config
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          serviceAccountName: tekton-bot
+  schedule: 0 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: true

--- a/env/templates/arcalos-version-stream-update-cj.yaml
+++ b/env/templates/arcalos-version-stream-update-cj.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: arcalos-version-stream-update
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: arcalos-version-stream-update
+            release: jx
+        spec:
+          containers:
+          - args:
+            - step
+            - create
+            - pr
+            - versions
+            - --repo
+            - https://github.com/cloudbees/arcalos-jenkins-x-versions
+            - --filter=*
+            - --images
+            - --excludes=jetstack/cert-manager
+            - --excludes=jx-labs/jxl-boot
+            - --excludes=stable/nginx-ingress  # Stick with 1.34.2 due to https://github.com/helm/charts/pull/21654 breaking upgrades
+            - --batch-mode
+            - --verbose
+            command:
+            - jx
+            env:
+            - name: GIT_COMMITTER_EMAIL
+              value: jenkins-x@googlegroups.com
+            - name: GIT_AUTHOR_EMAIL
+              value: jenkins-x@googlegroups.com
+            - name: GIT_AUTHOR_NAME
+              value: jenkins-x-bot
+            - name: PIPELINE_KIND
+              value: release
+            image: gcr.io/jenkinsxio/builder-go:{{ .Values.versions.builders }}
+            imagePullPolicy: IfNotPresent
+            name: arcalos-version-stream-update
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          serviceAccountName: tekton-bot
+  schedule: 0 */12 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: true

--- a/env/templates/arcalos-versions-scheduler.yaml
+++ b/env/templates/arcalos-versions-scheduler.yaml
@@ -1,0 +1,57 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  name: arcalos-versions-scheduler
+spec:
+  plugins:
+    entries:
+      - label
+  postsubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      name: release
+      context: arcalos
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      context: arcalos
+      name: arcalos
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - arcalos
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      - labels:
+          entries:
+          - updatebot
+        milestone: ""
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test arcalos
+      trigger: (?m)^/test( all| arcalos),?(s+|$)

--- a/env/templates/bdd-jx-scheduler.yaml
+++ b/env/templates/bdd-jx-scheduler.yaml
@@ -1,0 +1,45 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  name: bdd-jx-scheduler
+spec:
+  plugins:
+    entries:
+      - label
+  postsubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      name: release
+      context: release
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      context: pr-build
+      name: pr-build
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - pr-build
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test this
+      trigger: (?m)^/test( all| this),?(\s+|$)

--- a/env/templates/boot-config-scheduler.yaml
+++ b/env/templates/boot-config-scheduler.yaml
@@ -1,0 +1,68 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  name: boot-config-scheduler
+spec:
+  merger:
+    mergeMethod: rebase
+  plugins:
+    entries:
+      - label
+  postsubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      name: release
+      context: release
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      context: bdd-local
+      name: bdd-local
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - bdd-local
+            - bdd-vault
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test bdd-local
+      trigger: (?m)^/test( all| bdd-local),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: bdd-vault
+      name: bdd-vault
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test bdd-vault
+      trigger: (?m)^/test( all| bdd-vault),?(s+|$)

--- a/env/templates/ci-scheduler.yaml
+++ b/env/templates/ci-scheduler.yaml
@@ -1,0 +1,72 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  creationTimestamp: null
+  name: ci-scheduler
+spec:
+  approve:
+    issueRequired: false
+    lgtmActsAsApprove: true
+    requireSelfApproval: true
+  merger:
+    blockerLabel: ""
+    maxGoroutines: 0
+    mergeMethod: merge
+    policy:
+      fromBranchProtection: true
+      optionalContexts: {}
+      requiredContexts: {}
+      requiredIfPresentContexts: {}
+      skipUnknownContexts: false
+    prStatusBaseUrl: ""
+    squashLabel: ""
+    targetUrl: http://deck{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
+  plugins:
+    entries:
+    - trigger
+    - override
+  policy:
+    protectTested: true
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      branches: {}
+      cluster: ""
+      context: ci
+      labels: {}
+      maxConcurrency: 0
+      mergeMethod: ""
+      name: ci
+      optional: false
+      policy:
+        Replace: false
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - ci
+      report: true
+      rerunCommand: /test this
+      runIfChanged: ""
+      skipBranches: {}
+      trigger: (?m)^/test( all| this),?(\s+|$)
+  postsubmits:
+    replace: true
+  trigger:
+    ignoreOkToTest: false
+    joinOrgUrl: ""
+    onlyOrgMembers: false
+    trustedOrg: {{ .Values.gitops.owner }}
+  welcome:
+  - message_template: Welcome
+  attachments:
+  - name: jobURLPrefix
+    urls:
+    - 'https://dashboard-jx.jenkins-x.live/teams'
+  - name: reportTemplate
+    urls:
+    - '{{`{{if eq .Spec.Type "presubmit"}}[View all Builds for this Pull Request](https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/PR-{{(index .Spec.Refs.Pulls 0).Number}}) {{else if eq .Spec.Type "batch"}} Run "jx get build log --owner {{.Spec.Refs.Org}} --repo {{.Spec.Refs.Repo}} --branch batch" whilst connected to the cluster. UI support coming soon. {{end}}`}}'
+  - name: jobURLTemplate
+    urls:
+    - '{{`{{if eq .Spec.Type "presubmit"}}https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/PR-{{(index .Spec.Refs.Pulls 0).Number}}/{{.Status.BuildID}}{{else if eq .Spec.Type "postsubmit"}}https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/{{.Spec.Refs.BaseRef}}/{{.Status.BuildID}}{{end}}`}}'

--- a/env/templates/default-scheduler.yaml
+++ b/env/templates/default-scheduler.yaml
@@ -1,0 +1,128 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  creationTimestamp: null
+  name: default-scheduler
+spec:
+  approve:
+    issueRequired: false
+    lgtmActsAsApprove: true
+    requireSelfApproval: true
+  merger:
+    blockerLabel: ""
+    maxGoroutines: 0
+    mergeMethod: merge
+    policy:
+      fromBranchProtection: true
+      optionalContexts: {}
+      requiredContexts: {}
+      requiredIfPresentContexts: {}
+      skipUnknownContexts: false
+    prStatusBaseUrl: ""
+    squashLabel: ""
+    targetUrl: http://deck{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
+  plugins:
+    entries:
+    - approve
+    - assign
+    - help
+    - hold
+    - lgtm
+    - lifecycle
+    - override
+    - size
+    - trigger
+    - wip
+    - cat
+    - dog
+    - pony
+    - override
+  policy:
+    protectTested: true
+  postsubmits:
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: ""
+      labels: {}
+      maxConcurrency: 0
+      name: release
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
+  presubmits:
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      branches: {}
+      cluster: ""
+      context: pr-build
+      labels: {}
+      maxConcurrency: 0
+      mergeMethod: ""
+      name: pr-build
+      optional: false
+      policy:
+        Replace: false
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - pr-build
+      queries:
+      - excludedBranches: {}
+        includedBranches: {}
+        labels:
+          entries:
+          - approved
+        milestone: ""
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+        reviewApprovedRequired: false
+      - excludedBranches: {}
+        includedBranches: {}
+        labels:
+          entries:
+          - updatebot
+        milestone: ""
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+        reviewApprovedRequired: false
+      report: true
+      rerunCommand: /test this
+      runIfChanged: ""
+      skipBranches: {}
+      trigger: (?m)^/test( all| this),?(\s+|$)
+  schedulerAgent:
+    agent: tekton
+  trigger:
+    ignoreOkToTest: false
+    joinOrgUrl: ""
+    onlyOrgMembers: false
+    trustedOrg: {{ .Values.gitops.owner }}
+  welcome:
+  - message_template: Welcome
+  attachments:
+  - name: jobURLPrefix
+    urls:
+    - 'https://dashboard-jx.jenkins-x.live/teams'
+  - name: reportTemplate
+    urls:
+    - '{{`{{if eq .Spec.Type "presubmit"}}[View all Builds for this Pull Request](https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/PR-{{(index .Spec.Refs.Pulls 0).Number}}) {{else if eq .Spec.Type "batch"}} Run "jx get build log --owner {{.Spec.Refs.Org}} --repo {{.Spec.Refs.Repo}} --branch batch" whilst connected to the cluster. UI support coming soon. {{end}}`}}'
+  - name: jobURLTemplate
+    urls:
+    - '{{`{{if eq .Spec.Type "presubmit"}}https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/PR-{{(index .Spec.Refs.Pulls 0).Number}}/{{.Status.BuildID}}{{else if eq .Spec.Type "postsubmit"}}https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/{{.Spec.Refs.BaseRef}}/{{.Status.BuildID}}{{end}}`}}'

--- a/env/templates/dev-env-scheduler.yaml
+++ b/env/templates/dev-env-scheduler.yaml
@@ -1,0 +1,116 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  creationTimestamp: null
+  name: dev-env-scheduler
+spec:
+  approve:
+    issueRequired: false
+    lgtmActsAsApprove: true
+    requireSelfApproval: true
+  merger:
+    blockerLabel: ""
+    maxGoroutines: 0
+    mergeMethod: merge
+    policy:
+      fromBranchProtection: true
+      optionalContexts: {}
+      requiredContexts: {}
+      requiredIfPresentContexts: {}
+      skipUnknownContexts: false
+    prStatusBaseUrl: ""
+    squashLabel: ""
+    targetUrl: http://deck{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
+  plugins:
+    entries:
+    - approve
+    - assign
+    - help
+    - hold
+    - lgtm
+    - lifecycle
+    - size
+    - trigger
+    - wip
+    - cat
+    - override
+  policy:
+    protectTested: true
+  postsubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: ""
+      labels: {}
+      maxConcurrency: 0
+      name: promotion
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      branches: {}
+      cluster: ""
+      context: promotion-build
+      labels: {}
+      maxConcurrency: 0
+      mergeMethod: ""
+      name: promotion-build
+      optional: false
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - promotion-build
+      queries:
+      - excludedBranches: {}
+        includedBranches: {}
+        labels:
+          entries:
+          - approved
+        milestone: ""
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+        reviewApprovedRequired: false
+      - excludedBranches: {}
+        includedBranches: {}
+        labels:
+          entries:
+            - updatebot
+        milestone: ""
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+        reviewApprovedRequired: false
+      report: true
+      rerunCommand: /test this
+      runIfChanged: ""
+      skipBranches: {}
+      trigger: (?m)^/test( all| this),?(\s+|$)
+  schedulerAgent:
+    agent: tekton
+  trigger:
+    ignoreOkToTest: false
+    joinOrgUrl: ""
+    onlyOrgMembers: false
+    trustedOrg: {{ .Values.gitops.owner }}
+  welcome:
+  - message_template: Welcome

--- a/env/templates/e2e-gc-cj.yaml
+++ b/env/templates/e2e-gc-cj.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: jx-e2e-gc
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: e2e-gc
+            release: jx
+        spec:
+          containers:
+          - args:
+            - step
+            - e2e
+            - gc
+            - --project-id=jenkins-x-bdd3
+            - --batch-mode
+            command:
+            - jx
+            env:
+            - name: JX_LOG_FORMAT
+              value: json
+            - name: GKE_SA_KEY_FILE
+              value: "/builder/home/bdd-credentials.json"
+            image: gcr.io/jenkinsxio/builder-go:2.1.20-646
+            imagePullPolicy: IfNotPresent
+            name: e2e-gc
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+              - name: bdd-secret
+                mountPath: "/builder/home/"
+                readOnly: true
+          volumes:
+            - name: bdd-secret
+              secret:
+                secretName: bdd-secret
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: 0/10 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: true

--- a/env/templates/env-scheduler.yaml
+++ b/env/templates/env-scheduler.yaml
@@ -1,0 +1,101 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  creationTimestamp: null
+  name: env-scheduler
+spec:
+  approve:
+    issueRequired: false
+    lgtmActsAsApprove: true
+    requireSelfApproval: true
+  merger:
+    blockerLabel: ""
+    maxGoroutines: 0
+    mergeMethod: merge
+    policy:
+      fromBranchProtection: true
+      optionalContexts: {}
+      requiredContexts: {}
+      requiredIfPresentContexts: {}
+      skipUnknownContexts: false
+    prStatusBaseUrl: ""
+    squashLabel: ""
+    targetUrl: http://deck{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
+  plugins:
+    entries:
+    - approve
+    - assign
+    - help
+    - hold
+    - lgtm
+    - lifecycle
+    - size
+    - trigger
+    - wip
+    - cat
+    - override
+  policy:
+    protectTested: true
+  postsubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: ""
+      labels: {}
+      maxConcurrency: 0
+      name: promotion
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      branches: {}
+      cluster: ""
+      context: promotion-build
+      labels: {}
+      maxConcurrency: 0
+      mergeMethod: ""
+      name: promotion-build
+      optional: false
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - promotion-build
+      queries:
+      - excludedBranches: {}
+        includedBranches: {}
+        labels:
+          entries:
+          - approved
+        milestone: ""
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+        reviewApprovedRequired: false
+      report: true
+      rerunCommand: /test this
+      runIfChanged: ""
+      skipBranches: {}
+      trigger: (?m)^/test( all| this),?(\s+|$)
+  schedulerAgent:
+    agent: tekton
+  trigger:
+    ignoreOkToTest: false
+    joinOrgUrl: ""
+    onlyOrgMembers: false
+    trustedOrg: {{ .Values.gitops.owner }}
+  welcome:
+  - message_template: Welcome

--- a/env/templates/jx-issue-lifecycle-close-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-close-cj.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: jx-issue-lifecycle-close
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: jx-issue-lifecycle-close
+            release: jx
+        spec:
+          containers:
+          - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
+            command:
+            - /app/robots/commenter/app.binary
+            args:
+            - --query=org:jenkins-x -label:lifecycle/frozen label:lifecycle/rotten
+            - --updated=720h
+            - --token=/etc/token/oauth
+            - |-
+              --comment=Rotten issues close after 30d of inactivity.
+              Reopen the issue with `/reopen`.
+              Mark the issue as fresh with `/remove-lifecycle rotten`.
+              Provide feedback via https://jenkins-x.io/community.
+              /close
+            - --template
+            - --ceiling=10
+            - --confirm
+            imagePullPolicy: IfNotPresent
+            name: jx-issue-lifecycle-close
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - name: token
+              mountPath: /etc/token
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - name: token
+            secret:
+              secretName: lighthouse-oauth-token
+  schedule: 5 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/env/templates/jx-issue-lifecycle-rotten-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-rotten-cj.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: jx-issue-lifecycle-rotten
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: jx-issue-lifecycle-rotten
+            release: jx
+        spec:
+          containers:
+          - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
+            command:
+            - /app/robots/commenter/app.binary
+            args:
+            - --query=org:jenkins-x -label:lifecycle/frozen label:lifecycle/stale -label:lifecycle/rotten
+            - --updated=720h
+            - --token=/etc/token/oauth
+            - |-
+              --comment=Stale issues rot after 30d of inactivity.
+              Mark the issue as fresh with `/remove-lifecycle rotten`.
+              Rotten issues close after an additional 30d of inactivity.
+              If this issue is safe to close now please do so with `/close`.
+              Provide feedback via https://jenkins-x.io/community.
+              /lifecycle rotten
+            - --template
+            - --ceiling=10
+            - --confirm
+            imagePullPolicy: IfNotPresent
+            name: jx-issue-lifecycle-rotten
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - name: token
+              mountPath: /etc/token
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - name: token
+            secret:
+              secretName: lighthouse-oauth-token
+  schedule: 10 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/env/templates/jx-issue-lifecycle-stale-cj.yaml
+++ b/env/templates/jx-issue-lifecycle-stale-cj.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: jx-issue-lifecycle-stale
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: jx-issue-lifecycle-stale
+            release: jx
+        spec:
+          containers:
+          - image: gcr.io/k8s-prow/commenter:v20190528-0d7c4b53a
+            command:
+            - /app/robots/commenter/app.binary
+            args:
+            - --query=org:jenkins-x -label:lifecycle/frozen -label:lifecycle/stale -label:lifecycle/rotten
+            - --updated=2160h
+            - --token=/etc/token/oauth
+            - |-
+              --comment=Issues go stale after 90d of inactivity.
+              Mark the issue as fresh with `/remove-lifecycle stale`.
+              Stale issues rot after an additional 30d of inactivity and eventually close.
+              If this issue is safe to close now please do so with `/close`.
+              Provide feedback via https://jenkins-x.io/community.
+              /lifecycle stale
+            - --template
+            - --ceiling=30
+            - --confirm
+            imagePullPolicy: IfNotPresent
+            name: jx-issue-lifecycle-stale
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - name: token
+              mountPath: /etc/token
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - name: token
+            secret:
+              secretName: lighthouse-oauth-token
+  schedule: 0 * * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/env/templates/jx-scheduler.yaml
+++ b/env/templates/jx-scheduler.yaml
@@ -1,0 +1,251 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  name: jx-scheduler
+spec:
+  lgtm:
+    reviewActsAsLgtm: true
+  merger:
+    mergeMethod: rebase
+  plugins:
+    entries:
+      - label
+  postsubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      name: release
+      context: ""
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - whitesource
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: whitesource
+      labels: {}
+      maxConcurrency: 0
+      name: whitesource
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      context: integration
+      name: integration
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - integration
+            - tekton
+            - lint
+            - boot-vault
+            - tf-boot
+            - unit
+            - codegen
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test integration
+      trigger: (?m)^/test( all| integration),?(\s+|$)
+    - agent: tekton
+      alwaysRun: false
+      context: bdd
+      name: bdd
+      queries:
+        - labels:
+            entries:
+              - approved
+              - lgtm
+          missingLabels:
+            entries:
+              - do-not-merge
+              - do-not-merge/hold
+              - do-not-merge/work-in-progress
+              - needs-ok-to-test
+              - needs-rebase
+              - needs-security-review
+      report: true
+      rerunCommand: /test bdd
+      trigger: (?m)^/test( bdd),?(\s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: tekton
+      name: tekton
+      queries:
+      - labels:
+          entries:
+           - approved
+           - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      report: true
+      rerunCommand: /test tekton
+      trigger: (?m)^/test( all| tekton),?(\s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: lint
+      name: lint
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test lint
+      trigger: (?m)^/test( all| lint),?(\s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: codegen
+      name: codegen
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test codegen
+      trigger: (?m)^/test( all| codegen),?(\s+|$)      
+    - agent: tekton
+      alwaysRun: false
+      context: images
+      name: images
+      queries:
+        - labels:
+            entries:
+              - approved
+              - lgtm
+          missingLabels:
+            entries:
+              - do-not-merge
+              - do-not-merge/hold
+              - do-not-merge/work-in-progress
+              - needs-ok-to-test
+              - needs-rebase
+              - needs-security-review
+      report: true
+      rerunCommand: /build images
+      trigger: (?m)^/build images,?(\s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: boot-vault
+      name: boot-vault
+      queries:
+        - labels:
+            entries:
+              - approved
+              - lgtm
+          missingLabels:
+            entries:
+              - do-not-merge
+              - do-not-merge/hold
+              - do-not-merge/work-in-progress
+              - needs-ok-to-test
+              - needs-rebase
+              - needs-security-review
+      report: true
+      rerunCommand: /test boot-vault
+      trigger: (?m)^/test( all| boot| boot-vault),?(\s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: tf-boot
+      name: tf-boot
+      queries:
+        - labels:
+            entries:
+              - approved
+              - lgtm
+          missingLabels:
+            entries:
+              - do-not-merge
+              - do-not-merge/hold
+              - do-not-merge/work-in-progress
+              - needs-ok-to-test
+              - needs-rebase
+              - needs-security-review
+      report: true
+      rerunCommand: /test tf-boot
+      trigger: (?m)^/test( all| tf-boot),?(\s+|$)      
+    - agent: tekton
+      alwaysRun: true
+      context: unit
+      name: unit
+      queries:
+        - labels:
+            entries:
+              - approved
+              - lgtm
+          missingLabels:
+            entries:
+              - do-not-merge
+              - do-not-merge/hold
+              - do-not-merge/work-in-progress
+              - needs-ok-to-test
+              - needs-rebase
+              - needs-security-review
+      report: true
+      rerunCommand: /test unit
+      trigger: (?m)^/test unit,?(\s+|$)      
+    - agent: tekton
+      alwaysRun: false
+      context: boot-lh-ghe
+      name: boot-lh-ghe
+      queries:
+        - labels:
+            entries:
+              - approved
+              - lgtm
+          missingLabels:
+            entries:
+              - do-not-merge
+              - do-not-merge/hold
+              - do-not-merge/work-in-progress
+              - needs-ok-to-test
+              - needs-rebase
+              - needs-security-review
+      report: true
+      rerunCommand: /test boot-lh-ghe
+      trigger: (?m)^/test boot-lh-ghe,?(\s+|$)

--- a/env/templates/jx-versions-scheduler.yaml
+++ b/env/templates/jx-versions-scheduler.yaml
@@ -1,0 +1,472 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  name: jx-versions-scheduler
+spec:
+  plugins:
+    entries:
+      - label
+  postsubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      name: release
+      context: ""
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: false
+      context: static
+      name: static
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test static
+      trigger: (?m)^/test( static),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: tekton
+      name: tekton
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+              - tekton
+              - boot-local
+              - boot-vault
+              - boot-vault-tls
+              - boot-lh-ghe
+              - boot-vault-upgrade
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test tekton
+      trigger: (?m)^/test( all| tekton),?(s+|$)
+    - agent: tekton
+      alwaysRun: false
+      context: boot-helm3
+      name: boot-helm3
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test boot-helm3
+      trigger: (?m)^/test( all| boot-helm3),?(s+|$)
+    - agent: tekton
+      alwaysRun: false
+      context: boot-helm3-mc
+      name: boot-helm3-mc
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test boot-helm3-mc
+      trigger: (?m)^/test( all| boot-helm3-mc),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: boot-local
+      name: boot-local
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test boot-local
+      trigger: (?m)^/test( all| boot| boot-local),?(s+|$)
+    - agent: tekton
+      alwaysRun: false
+      context: boot-jenkins
+      name: boot-jenkins
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test boot-jenkins
+      trigger: (?m)^/test( boot| boot-jenkins),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: boot-vault
+      name: boot-vault
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test boot-vault
+      trigger: (?m)^/test( all| boot| boot-vault),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: boot-vault-tls
+      name: boot-vault-tls
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test boot-vault-tls
+      trigger: (?m)^/test( all| boot| boot-vault-tls),?(s+|$)
+    - agent: tekton
+      alwaysRun: false
+      context: bucketrepo
+      name: bucketrepo
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test bucketrepo
+      trigger: (?m)^/test( all| boot| bucketrepo| lighthouse),?(s+|$)
+    - agent: tekton
+      alwaysRun: false
+      context: boot-lh
+      name: boot-lh
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test boot-lh
+      trigger: (?m)^/test( all| boot| boot-lh| lighthouse),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: boot-lh-ghe
+      name: boot-lh-ghe
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test boot-lh-ghe
+      trigger: (?m)^/test( all| boot| boot-lh-ghe| lighthouse),?(s+|$)
+    - agent: tekton
+      alwaysRun: false
+      context: boot-lh-bs
+      name: boot-lh-bs
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test boot-lh-bs
+      trigger: (?m)^/test( boot| boot-lh-bs| lighthouse),?(s+|$)
+    - agent: tekton
+      alwaysRun: false
+      context: boot-lh-gl
+      name: boot-lh-gl
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test boot-lh-gl
+      trigger: (?m)^/test( boot| boot-lh-gl| lighthouse),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: boot-vault-upgrade
+      name: boot-vault-upgrade
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test boot-vault-upgrade
+      trigger: (?m)^/test( boot-vault-upgrade),?(s+|$)  
+    - agent: tekton
+      alwaysRun: false
+      context: devpods
+      name: devpods
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test devpods
+      trigger: (?m)^/test( devpods),?(s+|$)

--- a/env/templates/lh-scheduler.yaml
+++ b/env/templates/lh-scheduler.yaml
@@ -1,0 +1,232 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  name: lh-scheduler
+spec:
+  plugins:
+    entries:
+      - label
+  postsubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      name: release
+      context: ""
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - whitesource
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: whitesource
+      labels: {}
+      maxConcurrency: 0
+      name: whitesource
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
+  presubmits:
+    replace: true
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      context: pr-build
+      name: pr-build
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - pr-build
+            - github
+            - ghe
+            - gitlab
+            - bbs
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test pr-build
+      trigger: (?m)^/test( all| pr-build),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: ghe
+      name: ghe
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test ghe
+      trigger: (?m)^/test( all| bdd| all-gh| ghe),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: github
+      name: github
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test github
+      trigger: (?m)^/test( all| bdd| all-gh| github),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: bbs
+      name: bbs
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test bbs
+      trigger: (?m)^/test( all| bdd| bbs),?(s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: gitlab
+      name: gitlab
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      - labels:
+          entries:
+            - updatebot
+        missingLabels:
+          entries:
+            - do-not-merge
+            - do-not-merge/hold
+            - do-not-merge/work-in-progress
+            - needs-ok-to-test
+            - needs-rebase
+            - needs-security-review
+      report: true
+      rerunCommand: /test gitlab
+      trigger: (?m)^/test( all| bdd| gitlab),?(s+|$)
+    - agent: tekton
+      alwaysRun: false
+      context: migrate-from-prow
+      name: migrate-from-prow
+      queries:
+        - labels:
+            entries:
+              - approved
+              - lgtm
+          missingLabels:
+            entries:
+              - do-not-merge
+              - do-not-merge/hold
+              - do-not-merge/work-in-progress
+              - needs-ok-to-test
+              - needs-rebase
+              - needs-security-review
+        - labels:
+            entries:
+              - updatebot
+          missingLabels:
+            entries:
+              - do-not-merge
+              - do-not-merge/hold
+              - do-not-merge/work-in-progress
+              - needs-ok-to-test
+              - needs-rebase
+              - needs-security-review
+      report: true
+      rerunCommand: /test migrate-from-prow
+      trigger: (?m)^/test migrate-from-prow,?(s+|$)

--- a/env/templates/rebase-and-lgtm-scheduler.yaml
+++ b/env/templates/rebase-and-lgtm-scheduler.yaml
@@ -1,0 +1,66 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  name: rebase-and-lgtm-scheduler
+spec:
+  merger:
+    mergeMethod: rebase
+  plugins:
+    entries:
+      - label
+  postsubmits:
+    replace: true
+    entries:
+      - agent: tekton
+        branches:
+          entries:
+            - master
+        cluster: ""
+        context: ""
+        labels: {}
+        maxConcurrency: 0
+        name: release
+        report: false
+        runIfChanged: ""
+        skipBranches: {}
+  presubmits:
+    replace: true
+    entries:
+      - agent: tekton
+        alwaysRun: true
+        branches: {}
+        cluster: ""
+        context: pr-build
+        labels: {}
+        maxConcurrency: 0
+        mergeMethod: ""
+        name: pr-build
+        optional: false
+        policy:
+          Replace: false
+          requiredStatusChecks:
+            contexts:
+              entries:
+                - pr-build
+        queries:
+          - excludedBranches: {}
+            includedBranches: {}
+            labels:
+              entries:
+                - approved
+                - lgtm
+            milestone: ""
+            missingLabels:
+              entries:
+                - do-not-merge
+                - do-not-merge/hold
+                - do-not-merge/work-in-progress
+                - needs-ok-to-test
+                - needs-rebase
+                - needs-security-review
+            reviewApprovedRequired: false
+        report: true
+        rerunCommand: /test this
+        runIfChanged: ""
+        skipBranches: {}
+        trigger: (?m)^/test( all| this),?(\s+|$)

--- a/env/templates/sync-nginx-images-cj.yaml
+++ b/env/templates/sync-nginx-images-cj.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: sync-nginx-images-to-gcr
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: sync-nginx-images
+            release: jx
+        spec:
+          containers:
+          - command: ["./sync-nginx-images.sh"]
+            image: quay.io/skopeo/upstream
+            imagePullPolicy: IfNotPresent
+            name: sync-images
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - name: kaniko-secret
+              mountPath: /kaniko-secrets
+            - name: sync-nginx-images-script
+              mountPath: /sync-nginx-images.sh
+              subPath: sync-nginx-images.sh
+          volumes:
+          - name: kaniko-secret
+            secret:
+              secretName: kaniko-secret
+              items:
+              - key: kaniko-secret
+                path: kaniko/kaniko-secret.json
+          - name: sync-nginx-images-script
+            configMap:
+              name: sync-nginx-images-script
+              defaultMode: 0777
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: 0 */12 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/env/templates/sync-nginx-images-script-cm.yaml
+++ b/env/templates/sync-nginx-images-script-cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sync-nginx-images-script
+data:
+  sync-nginx-images.sh: |
+    #!/bin/sh
+    cat /kaniko-secrets/kaniko/kaniko-secret.json | /bin/skopeo login -u _json_key --password-stdin https://gcr.io
+    /bin/skopeo sync --src docker --dest docker quay.io/kubernetes-ingress-controller/nginx-ingress-controller gcr.io/jenkinsxio

--- a/env/templates/whitesource-scheduler.yaml
+++ b/env/templates/whitesource-scheduler.yaml
@@ -1,0 +1,167 @@
+apiVersion: jenkins.io/v1
+kind: Scheduler
+metadata:
+  creationTimestamp: null
+  name: whitesource-scheduler
+spec:
+  approve:
+    issueRequired: false
+    lgtmActsAsApprove: true
+    requireSelfApproval: true
+  merger:
+    blockerLabel: ""
+    maxGoroutines: 0
+    mergeMethod: merge
+    policy:
+      fromBranchProtection: true
+      optionalContexts: {}
+      requiredContexts: {}
+      requiredIfPresentContexts: {}
+      skipUnknownContexts: false
+    prStatusBaseUrl: ""
+    squashLabel: ""
+    targetUrl: http://deck{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}
+  plugins:
+    entries:
+    - approve
+    - assign
+    - help
+    - hold
+    - lgtm
+    - lifecycle
+    - override
+    - size
+    - trigger
+    - wip
+    - cat
+    - dog
+    - pony
+    - override
+  policy:
+    protectTested: true
+  postsubmits:
+    entries:
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: ""
+      labels: {}
+      maxConcurrency: 0
+      name: release
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
+      policy:
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - whitesource
+    - agent: tekton
+      branches:
+        entries:
+        - master
+      cluster: ""
+      context: whitesource
+      labels: {}
+      maxConcurrency: 0
+      name: whitesource
+      report: false
+      runIfChanged: ""
+      skipBranches: {}
+  presubmits:
+    entries:
+    - agent: tekton
+      alwaysRun: true
+      branches: {}
+      cluster: ""
+      context: pr-build
+      labels: {}
+      maxConcurrency: 0
+      mergeMethod: ""
+      name: pr-build
+      optional: false
+      policy:
+        Replace: false
+        requiredStatusChecks:
+          contexts:
+            entries:
+            - pr-build
+            - lint
+      queries:
+      - excludedBranches: {}
+        includedBranches: {}
+        labels:
+          entries:
+          - approved
+        milestone: ""
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+        reviewApprovedRequired: false
+      - excludedBranches: {}
+        includedBranches: {}
+        labels:
+          entries:
+          - updatebot
+        milestone: ""
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+        reviewApprovedRequired: false
+      report: true
+      rerunCommand: /test this
+      runIfChanged: ""
+      skipBranches: {}
+      trigger: (?m)^/test( all| this),?(\s+|$)
+    - agent: tekton
+      alwaysRun: true
+      context: lint
+      name: lint
+      queries:
+      - labels:
+          entries:
+          - approved
+          - lgtm
+        missingLabels:
+          entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+          - needs-security-review
+      report: true
+      rerunCommand: /test lint
+      trigger: (?m)^/test( all| lint),?(\s+|$)
+
+  schedulerAgent:
+    agent: tekton
+  trigger:
+    ignoreOkToTest: false
+    joinOrgUrl: ""
+    onlyOrgMembers: false
+    trustedOrg: {{ .Values.gitops.owner }}
+  welcome:
+  - message_template: Welcome
+  attachments:
+  - name: jobURLPrefix
+    urls:
+    - 'https://dashboard-jx.jenkins-x.live/teams'
+  - name: reportTemplate
+    urls:
+    - '{{`{{if eq .Spec.Type "presubmit"}}[View all Builds for this Pull Request](https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/PR-{{(index .Spec.Refs.Pulls 0).Number}}) {{else if eq .Spec.Type "batch"}} Run "jx get build log --owner {{.Spec.Refs.Org}} --repo {{.Spec.Refs.Repo}} --branch batch" whilst connected to the cluster. UI support coming soon. {{end}}`}}'
+  - name: jobURLTemplate
+    urls:
+    - '{{`{{if eq .Spec.Type "presubmit"}}https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/PR-{{(index .Spec.Refs.Pulls 0).Number}}/{{.Status.BuildID}}{{else if eq .Spec.Type "postsubmit"}}https://dashboard-jx.jenkins-x.live/teams/{{.Spec.Namespace}}/projects/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/{{.Spec.Refs.BaseRef}}/{{.Status.BuildID}}{{end}}`}}'

--- a/env/values.tmpl.yaml
+++ b/env/values.tmpl.yaml
@@ -1,3 +1,224 @@
+cluster:
+  domain: {{ .Requirements.ingress.domain }}
+{{- if hasKey .Requirements.ingress "exposer" }}
+  exposer: {{ .Requirements.ingress.exposer }}
+{{- else if eq .Requirements.cluster.provider "openshift" }}
+  exposer: Route
+{{- else if eq .Requirements.cluster.provider "minishift" }}
+  exposer: Route
+{{- else }}
+  exposer: Ingress
+{{- end }}
+  namespace: {{ .Requirements.cluster.namespace | default "jx" }}
+  namespaceSubDomain: {{ .Requirements.ingress.namespaceSubDomain | default ".jx." }}
+{{- if hasKey .Requirements.cluster "project" }}
+  projectID: {{ .Requirements.cluster.project }}
+{{- else }}
+  projectID: ""
+{{- end }}
+{{- if hasKey .Requirements.cluster "zone" }}
+  zone:  {{ .Requirements.cluster.zone }}
+{{- else }}
+  zone: ""
+{{- end }}
+  name: ""
+{{- if hasKey .Requirements.cluster "provider" }}
+  provider:  {{ .Requirements.cluster.provider }}
+{{- end }}
+{{- if hasKey .Requirements.cluster "strictPermissions" }}
+  strictPermissions: {{ .Requirements.cluster.strictPermissions }}
+{{- end }}
+  serverUrl: ""
+{{- if .Requirements.ingress.tls.enabled }}
+  tls: true
+{{- else }}
+  tls: false
+{{- end }}
+
+gitops:
+  versionStreamUrl: {{ .Requirements.versionStream.url }}
+  versionStreamRef: {{ .Requirements.versionStream.ref }}
+
+  gitKind: {{ .Requirements.cluster.gitKind | default "github" }}
+  gitName: {{ .Requirements.cluster.gitName | default "github" }}
+{{- if hasKey .Requirements.cluster "gitPublic" }}
+  gitPublic: {{ .Requirements.cluster.gitPublic }}
+{{- end }}
+  server: {{ .Requirements.cluster.gitServer | default "https://github.com" }}
+  owner: {{ .Requirements.cluster.environmentGitOwner }}
+  webhook: {{ .Requirements.webhook | default "prow" | quote }}
+{{- if eq .Requirements.cluster.gitKind "bitbucketserver" }}
+  gitUrlPathPrefix: "/scm"
+{{- else }}
+  gitUrlPathPrefix: ""
+{{- end }}
+
+  dev:
+    server: ""
+{{- if .Requirements.gitops }}
+    repo: "{{ .Environments.dev.repository }}"
+    owner: "{{ .Environments.dev.owner }}"
+    envOrganisation: "{{ .Requirements.cluster.environmentGitOwner }}"
+{{- else }}
+    repo: ""
+    owner: ""
+    envOrganisation: ""
+{{- end }}
+{{- if eq .Requirements.cluster.provider "gke" }}
+    dockerRegistryOrg: "{{ .Requirements.cluster.project }}"
+{{- else }}
+    dockerRegistryOrg: ""
+{{- end }}
+
+{{- if hasKey .Requirements "buildPacks" }}
+    buildPackName: "{{ .Requirements.buildPacks.buildPackLibrary.name }}"
+    buildPackUrl: "{{ .Requirements.buildPacks.buildPackLibrary.gitURL }}"
+    buildPackRef: "{{ .Requirements.buildPacks.buildPackLibrary.gitRef }}"
+{{- end }}
+
+  staging:
+    repo: "{{ .Environments.staging.repository }}"
+    owner: "{{ .Environments.staging.owner | default .Requirements.cluster.environmentGitOwner }}"
+    server: ""
+    namespace: {{ .Requirements.cluster.namespace | default "jx" }}-staging
+{{- if hasKey .Environments.staging "remoteCluster" }}
+    remote: {{ .Environments.staging.remoteCluster | default "false" }}
+{{- end }}
+
+  production:
+    repo: "{{ .Environments.production.repository }}"
+    owner: "{{ .Environments.production.owner | default .Requirements.cluster.environmentGitOwner }}"
+    server: ""
+    namespace: {{ .Requirements.cluster.namespace | default "jx" }}-production
+{{- if hasKey .Environments.production "remoteCluster" }}
+    remote: {{ .Environments.production.remoteCluster | default "false" }}
+{{- end }}
+
+storage:
+  logs:
+    url: "{{ .Requirements.storage.logs.url }}"
+  reports:
+    url: "{{ .Requirements.storage.reports.url }}"
+  repository:
+    url: "{{ .Requirements.storage.repository.url }}"
+
+expose:
+  enabled: false
+
+cleanup:
+  enabled: false
+
+controllerbuild:
+  enabled: true
+controllerteam:
+  enabled: false
+controllerworkflow:
+  enabled: false
+jenkins:
+  enabled: false
+jenkins-x-platform:
+  chartmuseum:
+    enabled: true
+    env:
+      open:
+        AUTH_ANONYMOUS_GET: true
+        DISABLE_API: false
+#        STORAGE: google
+#        STORAGE_GOOGLE_BUCKET: chartmuseum.jenkins-x.io
+#        STORAGE_GOOGLE_PREFIX: charts
+#    gcp:
+#      secret:
+#        enabled: true
+#        key: gcs-chartmuseum.key.json
+#        name: gcs-jenkinsx-chartmuseum
+    image:
+      tag: v0.7.1
+  controllerbuild:
+    enabled: true
+  jenkins:
+    Agent:
+      PodTemplates:
+        Go:
+          Containers:
+            Go:
+              Image: jenkinsxio/builder-go:latest
+        Maven:
+          Containers:
+            Maven:
+              Image: jenkinsxio/builder-maven:latest
+          volumes:
+          - mountPath: /root/.m2/
+            secretName: jenkins-maven-settings
+            type: Secret
+          - mountPath: /home/jenkins/.docker
+            secretName: jenkins-docker-cfg
+            type: Secret
+        Nodejs:
+          Containers:
+            Nodejs:
+              Image: jenkinsxio/builder-nodejs:latest
+  monocular:
+    api:
+      livenessProbe:
+        initialDelaySeconds: 1000
+  nexus:
+    persistence:
+      size: 100Gi
+  postinstalljob:
+    enabled: "true"
+
+JenkinsXGitHub:
+  username: "{{ .Parameters.pipelineUser.username }}"
+  email: "{{ .Parameters.pipelineUser.email }}"
+  password: "{{ .Parameters.pipelineUser.token }}"
+
+{{- if .Requirements.ingress.tls }}
+certmanager:
+  production: "{{ .Requirements.ingress.tls.production }}"
+{{- if .Requirements.ingress.tls.enabled }}
+  email:  "{{ .Requirements.ingress.tls.email }}"
+{{- else }}
+  enabled: false
+{{- end }}
+{{- end }}
+
+lighthouse:
+{{- if eq .Requirements.webhook "lighthouse" }}
+  enabled: true
+{{- else }}
+  enabled: false
+{{- end }}
+
+nexus:
+{{- if eq .Requirements.repository "nexus" }}
+  enabled: true
+{{- else }}
+  enabled: false
+{{- end }}
+
+prow:
+{{- if eq .Requirements.webhook "prow" }}
+  enabled: true
+{{- else }}
+  enabled: false
+{{- end }}
+
+vault:
+{{- if eq .Requirements.secretStorage "vault" }}
+  enabled: true
+{{- else }}
+  enabled: false
+{{- end }}
+
+{{- if .Requirements.autoUpdate }}
+autoUpdate:
+  schedule: {{ .Requirements.autoUpdate.schedule | quote }}
+  enabled: {{ .Requirements.autoUpdate.enabled }}
+{{- end }}
+
+versions:
+  builders: {{ versionStream "docker" "gcr.io/jenkinsxio/builder-go" }}
+
 tekton:
 {{- if eq .Requirements.webhook "prow" }}
   enabled: true
@@ -24,10 +245,6 @@ datadog:
   appKey: vault:oss-weasel/arcalos/datadog-app:appKey
 
 JenkinsXBDD: vault:oss-weasel/sa/jenkins-x-bdd:json
-
-JenkinsXGitHub:
-  username: "{{ .Parameters.pipelineUser.username }}"
-  password: "{{ .Parameters.pipelineUser.token }}"
 
 JenkinsXGHETestUser:
   username: vault:oss-weasel/creds/jenkins-x-github-ent-test-user:username


### PR DESCRIPTION
Leaving the `copy-chart-index` cronjob since we need to move that the same time we move our chartmuseum config in general.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>