### PR TITLE
chore: Add jenkins-x/lighthouse repo, remove SDM apps

### DIFF
--- a/env/jx-sdm-app/values.tmpl.yaml
+++ b/env/jx-sdm-app/values.tmpl.yaml
@@ -1,8 +1,0 @@
-sdm:
-  account: cloudbees
-  installId: oss-weasel
-  privateKey: vault:oss-weasel/sdm:jxAppPrivateKey
-# As we have a lot pipeline activities on oss weasel
-resources:
-  limits:
-    memory: 1Gi

--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -35,9 +35,3 @@ dependencies:
 - name: plantuml
   repository: https://charts.gitlab.io/
   version: 0.1.12
-- name: tekton-sdm-app
-  repository: http://chartmuseum.jenkins-x.io
-  version: 0.0.23
-- name: jx-sdm-app
-  repository: http://chartmuseum.jenkins-x.io
-  version: 0.0.17

--- a/env/tekton-sdm-app/values.tmpl.yaml
+++ b/env/tekton-sdm-app/values.tmpl.yaml
@@ -1,4 +1,0 @@
-sdm:
-  account: cloudbees
-  installId: oss-weasel
-  privateKey: vault:oss-weasel/sdm:tektonAppPrivateKey

--- a/repositories/templates/jenkins-x.yaml
+++ b/repositories/templates/jenkins-x.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  labels:
+    owner: jenkins-x
+    provider: github
+    repository: lighthouse
+  name: jenkins-x-lighthouse
+  namespace: jx
+spec:
+  description: Imported application for jenkins-x/lighthouse
+  provider: https://github.com
+  providerName: github
+  org: jenkins-x
+  repo: lighthouse

--- a/repositories/templates/lh-group.yaml
+++ b/repositories/templates/lh-group.yaml
@@ -1,0 +1,12 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepositoryGroup
+metadata:
+  name: lh-group
+spec:
+  scheduler:
+    apiVersion: jenkins.io/v1
+    kind: Scheduler
+    name: lh-scheduler
+  repositories:
+  - name: jenkins-x-lighthouse
+    kind: SourceRepository


### PR DESCRIPTION
The SDM apps just don't work, so let's get rid of them for now at least.

But more importantly, add the lighthouse repo as a trial run for things actually working correctly.

Merge this after https://github.com/jenkins-x/environment-tekton-weasel-dev/pull/628 has merged and been applied to tekton-weasel.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>