### PR TITLE
fix: Add the copy-chart-index cronjob

### DIFF
--- a/env/templates/copy-charts-index-cj.yaml
+++ b/env/templates/copy-charts-index-cj.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    app: gcs-copy
+  name: copy-charts-index
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          initContainers:
+          - name: prepare-chart-index
+            # curl the index.yaml file from chartmuseum before attempting a copy. This causes it to regenerate.
+            # No need to wait afterwards as the http call won't return until it's ready
+            image: gcr.io/jenkinsxio/builder-go:{{ .Values.versions.builders }}
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: URL
+                value: http://jenkins-x-chartmuseum:8080/index.yaml
+            command:
+              # Runs curl and only outputs errors
+              - curl
+            args:
+              - --show-error
+              - --silent
+              - --output
+              - /dev/null
+              - $(URL)
+          containers:
+          - command:
+              - /bin/bash
+            args:
+              - -c
+              - gcloud auth activate-service-account --key-file=/gcs-jenkinsx-chartmuseum/gcs-chartmuseum.key.json
+                && gsutil -h 'Cache-Control:no-cache,max-age=0,no-transform' cp gs://chartmuseum.jenkins-x.io/charts/index-cache.yaml
+                gs://chartmuseum.jenkins-x.io/index.yaml
+            image: gcr.io/jenkinsxio/builder-go:{{ .Values.versions.builders }}
+            imagePullPolicy: IfNotPresent
+            name: copy-chart-index-to-gcs
+            volumeMounts:
+            - mountPath: /gcs-jenkinsx-chartmuseum
+              name: gcs-jenkinsx-chartmuseum
+              readOnly: true
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          volumes:
+          - name: gcs-jenkinsx-chartmuseum
+            secret:
+              secretName: gcs-jenkinsx-chartmuseum
+  schedule: '*/2 * * * *'
+  successfulJobsHistoryLimit: 3
+  suspend: false


### PR DESCRIPTION
Since we've got chartmuseum set up properly here.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>