### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jenkins-x-apps/jx-app-ingress](https://github.com/jenkins-x-apps/jx-app-ingress.git) |  | []() | 
+[jenkins-x-apps/jx-app-flagger](https://github.com/jenkins-x-apps/jx-app-flagger.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[jenkins-x-apps/jx-app-ingress](https://github.com/jenkins-x-apps/jx-app-ingress.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jenkins-x-apps/jx-app-owasp-zap](https://github.com/jenkins-x-apps/jx-app-owasp-zap.git) |  | []() | 
+[jenkins-x-apps/jx-app-flagger](https://github.com/jenkins-x-apps/jx-app-flagger.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jenkins-x-apps/jx-app-flagger](https://github.com/jenkins-x-apps/jx-app-flagger.git) |  | []() | 
+[jenkins-x-apps/jx-app-owasp-zap](https://github.com/jenkins-x-apps/jx-app-owasp-zap.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jenkins-x-apps
-  repo: jx-app-flagger
-  url: https://github.com/jenkins-x-apps/jx-app-flagger.git
+  repo: jx-app-owasp-zap
+  url: https://github.com/jenkins-x-apps/jx-app-owasp-zap.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: jenkins-x-apps
+  repo: jx-app-ingress
+  url: https://github.com/jenkins-x-apps/jx-app-ingress.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jenkins-x-apps
-  repo: jx-app-owasp-zap
-  url: https://github.com/jenkins-x-apps/jx-app-owasp-zap.git
+  repo: jx-app-flagger
+  url: https://github.com/jenkins-x-apps/jx-app-flagger.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jenkins-x-apps
-  repo: jx-app-ingress
-  url: https://github.com/jenkins-x-apps/jx-app-ingress.git
+  repo: jx-app-flagger
+  url: https://github.com/jenkins-x-apps/jx-app-flagger.git
   version: ""
   versionURL: ""

--- a/repositories/templates/jenkins-x-apps-jx-app-flagger-sr.yaml
+++ b/repositories/templates/jenkins-x-apps-jx-app-flagger-sr.yaml
@@ -1,6 +1,10 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "2"
+    jenkins.io/last-build-number-for-pr-2: "1"
+    jenkins.io/last-build-number-for-pr-3: "9"
   creationTimestamp: null
   labels:
     owner: jenkins-x-apps

--- a/repositories/templates/jenkins-x-apps-jx-app-flagger-sr.yaml
+++ b/repositories/templates/jenkins-x-apps-jx-app-flagger-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jenkins-x-apps
+    provider: github
+    repository: jx-app-flagger
+  name: jenkins-x-apps-jx-app-flagger
+spec:
+  description: Imported application for jenkins-x-apps/jx-app-flagger
+  httpCloneURL: https://github.com/jenkins-x-apps/jx-app-flagger.git
+  org: jenkins-x-apps
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-app-flagger
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jenkins-x-apps/jx-app-flagger.git

--- a/repositories/templates/jenkins-x-apps-jx-app-ingress-sr.yaml
+++ b/repositories/templates/jenkins-x-apps-jx-app-ingress-sr.yaml
@@ -1,0 +1,24 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "2"
+    jenkins.io/last-build-number-for-pr-2: "1"
+  creationTimestamp: null
+  labels:
+    owner: jenkins-x-apps
+    provider: github
+    repository: jx-app-ingress
+  name: jenkins-x-apps-jx-app-ingress
+spec:
+  description: Imported application for jenkins-x-apps/jx-app-ingress
+  httpCloneURL: https://github.com/jenkins-x-apps/jx-app-ingress.git
+  org: jenkins-x-apps
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-app-ingress
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jenkins-x-apps/jx-app-ingress.git

--- a/repositories/templates/jenkins-x-apps-jx-app-owasp-zap-sr.yaml
+++ b/repositories/templates/jenkins-x-apps-jx-app-owasp-zap-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jenkins-x-apps
+    provider: github
+    repository: jx-app-owasp-zap
+  name: jenkins-x-apps-jx-app-owasp-zap
+spec:
+  description: Imported application for jenkins-x-apps/jx-app-owasp-zap
+  httpCloneURL: https://github.com/jenkins-x-apps/jx-app-owasp-zap.git
+  org: jenkins-x-apps
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-app-owasp-zap
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jenkins-x-apps/jx-app-owasp-zap.git


### PR DESCRIPTION
Update [jenkins-x-apps/jx-app-flagger](https://github.com/jenkins-x-apps/jx-app-flagger.git) 

Command run was `jx import --url https://github.com/jenkins-x-apps/jx-app-flagger --no-draft`
<hr />

Update [jenkins-x-apps/jx-app-owasp-zap](https://github.com/jenkins-x-apps/jx-app-owasp-zap.git) 

Command run was `jx import --url https://github.com/jenkins-x-apps/jx-app-owasp-zap --no-draft`
<hr />

Update [jenkins-x-apps/jx-app-flagger](https://github.com/jenkins-x-apps/jx-app-flagger.git) 

Command run was `jx import --url https://github.com/jenkins-x-apps/jx-app-flagger --no-draft`
<hr />

Update [jenkins-x-apps/jx-app-ingress](https://github.com/jenkins-x-apps/jx-app-ingress.git) 

Command run was `jx import --url https://github.com/jenkins-x-apps/jx-app-ingress --no-draft`