### PR TITLE
chore: Cut lifetime of e2e clusters to 1 hour from 2.

### DIFF
--- a/env/templates/e2e-gc-cj.yaml
+++ b/env/templates/e2e-gc-cj.yaml
@@ -22,6 +22,7 @@ spec:
             - e2e
             - gc
             - --project-id=jenkins-x-bdd3
+            - --duration=1
             - --batch-mode
             command:
             - jx


### PR DESCRIPTION
This could cause problems if there are any particularly long-running tests that legitimately should take more than an hour from cluster creation til completion, but I don't think there are any of those.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>