### PR TITLE
chore: Remove unneeded GitHub and GitLab contexts from Lighthouse

### DIFF
--- a/env/templates/lh-scheduler.yaml
+++ b/env/templates/lh-scheduler.yaml
@@ -48,9 +48,7 @@ spec:
           contexts:
             entries:
             - pr-build
-            - github
             - ghe
-            - gitlab
             - bbs
             - tekton
             - jenkins
@@ -114,37 +112,6 @@ spec:
       trigger: (?m)^/test( all| bdd| all-gh| ghe),?(s+|$)
     - agent: tekton
       alwaysRun: true
-      context: github
-      name: github
-      queries:
-      - labels:
-          entries:
-          - approved
-          - lgtm
-        missingLabels:
-          entries:
-          - do-not-merge
-          - do-not-merge/hold
-          - do-not-merge/work-in-progress
-          - needs-ok-to-test
-          - needs-rebase
-          - needs-security-review
-      - labels:
-          entries:
-            - updatebot
-        missingLabels:
-          entries:
-            - do-not-merge
-            - do-not-merge/hold
-            - do-not-merge/work-in-progress
-            - needs-ok-to-test
-            - needs-rebase
-            - needs-security-review
-      report: true
-      rerunCommand: /test github
-      trigger: (?m)^/test( all| bdd| all-gh| github),?(s+|$)
-    - agent: tekton
-      alwaysRun: true
       context: bbs
       name: bbs
       queries:
@@ -174,37 +141,6 @@ spec:
       report: true
       rerunCommand: /test bbs
       trigger: (?m)^/test( all| bdd| bbs),?(s+|$)
-    - agent: tekton
-      alwaysRun: true
-      context: gitlab
-      name: gitlab
-      queries:
-      - labels:
-          entries:
-          - approved
-          - lgtm
-        missingLabels:
-          entries:
-          - do-not-merge
-          - do-not-merge/hold
-          - do-not-merge/work-in-progress
-          - needs-ok-to-test
-          - needs-rebase
-          - needs-security-review
-      - labels:
-          entries:
-            - updatebot
-        missingLabels:
-          entries:
-            - do-not-merge
-            - do-not-merge/hold
-            - do-not-merge/work-in-progress
-            - needs-ok-to-test
-            - needs-rebase
-            - needs-security-review
-      report: true
-      rerunCommand: /test gitlab
-      trigger: (?m)^/test( all| bdd| gitlab),?(s+|$)
     - agent: tekton
       alwaysRun: true
       context: jenkins


### PR DESCRIPTION
Once https://github.com/jenkins-x/lighthouse/pull/1107 merges, we'll have `jenkins` covering github.com and `tekton` covering gitlab.com, so there's no need to have separate contexts for github.com and gitlab.com using jx.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>